### PR TITLE
[PROD-1189] - set correct_rationale to correct value in case of empty optional field.

### DIFF
--- a/ubcpi/static/js/spec/ubcpi_edit_spec.js
+++ b/ubcpi/static/js/spec/ubcpi_edit_spec.js
@@ -381,7 +381,73 @@ describe('UBCPI_Edit module', function () {
                 expect(mockNotify.calls.count()).toBe(3);
             });
         });
-    })
+    });
+    describe('EditSettingsControllerWithoutOptionalParam', function () {
+        var $rootScope, createController, controller, expectedCorrectRationale;
+
+        beforeEach(inject(function ($controller, _$rootScope_) {
+            mockConfig.data = {
+                "image_position_locations": {"below": "Appears below", "above": "Appears above"},
+                "rationale_size": {"max": 32000, "min": 1},
+                "display_name": "Peer Instruction",
+                "algo": {"num_responses": "#", "name": "simple"},
+                "algos": {
+                    "simple": "System will select one of each option to present to the students.",
+                    "random": "Completely random selection from the response pool."
+                },
+                "correct_answer": 1,
+                "seeds": [
+                    {answer:2, rationale:'rationale3'},
+                    {answer:1, rationale:'rationale2'},
+                    {answer:0, rationale:'rationale1'},
+                    {answer:2, rationale:'rationale3'},
+                    {answer:1, rationale:'rationale2'},
+                    {answer:0, rationale:'rationale1'}
+
+                ],
+                "question_text": {
+                    "text": "What is the answer to life, the universe and everything?",
+                    "image_show_fields": 0,
+                    "image_url": "",
+                    "image_position": "below",
+                    "image_alt": ""
+                },
+                "options": [
+                    {
+                        "text": "21",
+                        "image_show_fields": 0,
+                        "image_url": "",
+                        "image_position": "below",
+                        "image_alt": ""
+                    }
+                ]
+            };
+
+            $rootScope = _$rootScope_;
+            createController = function (params) {
+                return $controller(
+                    'EditSettingsController', {
+                        $scope: $rootScope,
+                        $stateParams: params || {}
+                    });
+            };
+            controller = createController();
+            expectedCorrectRationale = {"text": ""};
+        }));
+
+        it('should have correct initial states', function () {
+            expect(controller.algos).toBe(mockConfig.data.algos);
+            expect(controller.data.display_name).toBe(mockConfig.data.display_name);
+            expect(controller.data.question_text).toBe(mockConfig.data.question_text);
+            expect(controller.data.rationale_size).toBe(mockConfig.data.rationale_size);
+            expect(controller.image_position_locations).toBe(mockConfig.data.image_position_locations);
+            expect(controller.data.options).toBe(mockConfig.data.options);
+            expect(controller.data.correct_answer).toBe(mockConfig.data.correct_answer);
+            expect(controller.data.correct_rationale).toEqual(expectedCorrectRationale);
+            expect(controller.data.algo).toBe(mockConfig.data.algo);
+            expect(controller.data.seeds).toBe(mockConfig.data.seeds);
+        });
+    });
 });
 
 describe('PIEdit function', function () {

--- a/ubcpi/static/js/src/ubcpi_edit.js
+++ b/ubcpi/static/js/src/ubcpi_edit.js
@@ -88,6 +88,8 @@ angular.module("ubcpi_edit", ['ngMessages', 'ngSanitize', 'ngCookies', 'gettext'
             self.data.correct_answer = data.correct_answer;
             if (data.correct_rationale)
                 self.data.correct_rationale = data.correct_rationale;
+            else
+                self.data.correct_rationale = {"text": ""};
             self.data.algo = data.algo;
             self.data.seeds = data.seeds;
 


### PR DESCRIPTION
## [PROD-1189](https://openedx.atlassian.net/browse/PROD-1189)

### Description
UBCPI (UBC Peer Instruction Tool for edX) is third-party package used by EDX for Peer instruction block. A recent ticket https://openedx.atlassian.net/browse/PROD-1173 was reported in which the display name was not being updated while editing this block. 
Upon investigation, it was noted that this third-party package expected a value (i.e. corrent_rationale)  at all times when updating/editing this block. In the reported case, the field Explanation which is OPTIONAL (responsible for correct_rationale value) was empty. As a result, whenever any field was updated on the block with this empty value, the block was not updated. 
This scenario occurs when we have a peer instruction block with the optional field (because n/a correct answer selected) and the course is exported and then imported back in.

### Sandbox
https://studio-saadyousafarbi.sandbox.edx.org/course/course-v1:edX+DemoX+Demo_Course


### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [ ] @awaisdar001 
- [x] @DawoudSheraz 

### Post-review
- [ ] Rebase and squash commits