### PR TITLE
[PROD-1440] - Handle fragment DeprecationWarning.

### DIFF
--- a/ubcpi/ubcpi.py
+++ b/ubcpi/ubcpi.py
@@ -13,7 +13,7 @@ from webob import Response
 from xblock.core import XBlock
 from xblock.exceptions import JsonHandlerError
 from xblock.fields import Scope, String, List, Dict, Integer, DateTime, Float
-from xblock.fragment import Fragment
+from web_fragments.fragment import Fragment
 from xblockutils.publish_event import PublishEventMixin
 from .utils import _  # pylint: disable=unused-import
 


### PR DESCRIPTION
### [PROD-1440](https://openedx.atlassian.net/browse/PROD-1440)

Reducing logs to free up space in Splunk for a more meaningful history. Handling DeprecationWarning got `fragment`

`DeprecationWarning: xblock.fragment is deprecated. Please use web_fragments.fragment instead`