### PR TITLE
[BD-6] Add python 3.8 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: python
 python:
-  - "2.7"
-  - "3.5"
-  - "3.6"
+  - 3.5
+  - 3.8
 
 install:
   - "gem install coveralls-lcov"


### PR DESCRIPTION
Add python 3.8 tests to travis and remove python 2.7 and 3.6 tests/

Note that this is agains the branch feanil/modernize which is fact the branch that is used in this PR 

https://github.com/ubc/ubcpi/pulls