### PR TITLE
fix: remove unused positional argument

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ def readme():
 
 setup(
     name='ubcpi-xblock',
-    version='1.0.0',
+    version='1.0.1',
     description='UBC Peer Instruction XBlock',
     long_description=readme(),
     license='Affero GNU General Public License v3 (GPLv3)',

--- a/ubcpi/ubcpi.py
+++ b/ubcpi/ubcpi.py
@@ -766,7 +766,7 @@ class PeerInstructionXBlock(XBlock, MissingDataFetcherMixin, PublishEventMixin):
         ]
 
     @classmethod
-    def parse_xml(cls, node, runtime, keys, id_generator):
+    def parse_xml(cls, node, runtime, keys):
         """
         Instantiate XBlock object from runtime XML definition.
 


### PR DESCRIPTION
Ticket: [TNL-11905](https://2u-internal.atlassian.net/browse/TNL-11905)
In this PR:
- remove unused positional argument that was causing below error: 
  ```
  Traceback (most recent call last):
  File "/edx/app/edxapp/edx-platform/xmodule/vertical_block.py", line 253, in definition_from_xml
    child_block = system.process_xml(etree.tostring(child, encoding='unicode'))
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/edx/app/edxapp/edx-platform/xmodule/modulestore/xml.py", line 163, in process_xml
    block = self.xblock_from_node(
            ^^^^^^^^^^^^^^^^^^^^^^
  File "/edx/app/edxapp/edx-platform/xmodule/x_module.py", line 1579, in xblock_from_node
    block = block_class.parse_xml(node, self, keys)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  TypeError: PeerInstructionXBlock.parse_xml() missing 1 required positional argument: 'id_generator'
  ```
- bump version